### PR TITLE
fix : cargo clippy warning and error 

### DIFF
--- a/src/info.rs
+++ b/src/info.rs
@@ -2,10 +2,16 @@
 mod cpu;
 #[path = "modules/de.rs"]
 mod de;
+#[path = "modules/disk.rs"]
+mod disk;
+#[path = "modules/gpu.rs"]
+mod gpu;
 #[path = "modules/host.rs"]
 mod host;
 #[path = "modules/kernel.rs"]
 mod kernel;
+#[path = "modules/machine.rs"]
+mod machine;
 #[path = "modules/mem.rs"]
 mod mem;
 #[path = "modules/os.rs"]
@@ -20,12 +26,6 @@ mod sh;
 mod up;
 #[path = "modules/user.rs"]
 mod user;
-#[path = "modules/disk.rs"]
-mod disk;
-#[path = "modules/gpu.rs"]
-mod gpu;
-#[path = "modules/machine.rs"]
-mod machine;
 
 pub fn info() {
     match (user::get_user(), host::get_host()) {
@@ -43,7 +43,7 @@ pub fn info() {
     if let Ok(kernel) = kernel::get_kernel() {
         println!("Kernel    : {}", kernel);
     }
-    
+
     if let Ok(machine) = machine::get_machine() {
         println!("Host      : {}", machine);
     }

--- a/src/modules/cpu.rs
+++ b/src/modules/cpu.rs
@@ -6,14 +6,12 @@ pub fn get_cpu() -> io::Result<String> {
     let file = File::open("/proc/cpuinfo")?; // /proc/cpuinfo contains the cpu informations
 
     // Read the file line by line
-    for line in io::BufReader::new(file).lines() {
-        if let Ok(line) = line {
-            // Check for the "model name" line
-            if line.starts_with("model name") {
-                // Extract the model name
-                let model_name = line.split(':').nth(1).map(|s| s.trim());
-                return Ok(model_name.unwrap_or("N/A").to_string());
-            }
+    for line in io::BufReader::new(file).lines().flatten() {
+        // Check for the "model name" line
+        if line.starts_with("model name") {
+            // Extract the model name
+            let model_name = line.split(':').nth(1).map(|s| s.trim());
+            return Ok(model_name.unwrap_or("N/A").to_string());
         }
     }
 

--- a/src/modules/disk.rs
+++ b/src/modules/disk.rs
@@ -1,5 +1,5 @@
-use std::process::{Command, exit};
 use std::io;
+use std::process::{exit, Command};
 
 pub fn get_disk() -> io::Result<String> {
     // Run the df command and capture its output

--- a/src/modules/gpu.rs
+++ b/src/modules/gpu.rs
@@ -1,5 +1,5 @@
-use std::process::{Command, exit};
 use std::io;
+use std::process::{exit, Command};
 
 pub fn get_gpu() -> io::Result<String> {
     // Run the lspci command and capture its output
@@ -12,7 +12,9 @@ pub fn get_gpu() -> io::Result<String> {
             let output_str = String::from_utf8_lossy(&output.stdout);
 
             // Search for GPU-related information in the lspci output
-            if let Some(line) = output_str.lines().find(|line| line.to_lowercase().contains("vga") || line.to_lowercase().contains("3d")) {
+            if let Some(line) = output_str.lines().find(|line| {
+                line.to_lowercase().contains("vga") || line.to_lowercase().contains("3d")
+            }) {
                 // Extract the GPU model information
                 let gpu_model = line.split(':').nth(2).map(|s| s.trim());
 

--- a/src/modules/kernel.rs
+++ b/src/modules/kernel.rs
@@ -11,7 +11,7 @@ pub fn get_kernel() -> io::Result<String> {
             if output.status.success() {
                 // Convert the output to a string
                 let kernel_version = String::from_utf8_lossy(&output.stdout).trim().to_string();
-                return Ok(kernel_version);
+                Ok(kernel_version)
             } else {
                 // Print the error code and exit the program
                 eprintln!("Command failed with error code: {}", output.status);

--- a/src/modules/machine.rs
+++ b/src/modules/machine.rs
@@ -7,5 +7,5 @@ pub fn get_machine() -> io::Result<String> {
     let name = read_to_string(Path::new("/sys/devices/virtual/dmi/id/product_name"))?;
     let version = read_to_string(Path::new("/sys/devices/virtual/dmi/id/product_version"))?;
 
-    Ok(format!("{} {}", name.trim().to_string(), version.trim().to_string()))
+    Ok(format!("{} {}", name.trim(), version.trim()))
 }

--- a/src/modules/mem.rs
+++ b/src/modules/mem.rs
@@ -10,14 +10,12 @@ pub fn get_mem() -> io::Result<String> {
     let mut mem_free: u64 = 0;
 
     // Read the file line by line
-    for line in io::BufReader::new(file).lines() {
-        if let Ok(line) = line {
-            // Extract MemTotal and MemFree values
-            if line.starts_with("MemTotal:") {
-                mem_total = parse_memory_value(&line);
-            } else if line.starts_with("MemFree:") {
-                mem_free = parse_memory_value(&line);
-            }
+    for line in io::BufReader::new(file).lines().flatten() {
+        // Extract MemTotal and MemFree values
+        if line.starts_with("MemTotal:") {
+            mem_total = parse_memory_value(&line);
+        } else if line.starts_with("MemFree:") {
+            mem_free = parse_memory_value(&line);
         }
     }
 

--- a/src/modules/os.rs
+++ b/src/modules/os.rs
@@ -6,14 +6,12 @@ pub fn get_os() -> io::Result<String> {
     let file = File::open("/etc/os-release")?;
 
     // Read the file line by line
-    for line in io::BufReader::new(file).lines() {
-        if let Ok(line) = line {
-            // Check for the "PRETTY_NAME" field
-            if line.starts_with("PRETTY_NAME=") {
-                // Extract the value of PRETTY_NAME
-                let pretty_name = line.split('=').nth(1).map(|s| s.trim_matches('"'));
-                return Ok(pretty_name.unwrap_or("N/A").to_string());
-            }
+    for line in io::BufReader::new(file).lines().flatten() {
+        // Check for the "PRETTY_NAME" field
+        if line.starts_with("PRETTY_NAME=") {
+            // Extract the value of PRETTY_NAME
+            let pretty_name = line.split('=').nth(1).map(|s| s.trim_matches('"'));
+            return Ok(pretty_name.unwrap_or("N/A").to_string());
         }
     }
 

--- a/src/modules/pkg.rs
+++ b/src/modules/pkg.rs
@@ -8,10 +8,15 @@ pub fn get_pkg() -> io::Result<String> {
     if Path::new("/bin/dpkg").exists() {
         let output = Command::new("sh")
             .arg("-c")
-            .arg(format!("dpkg --get-selections | wc -l"))
+            .arg("dpkg --get-selections | wc -l")
             .output()?;
-        
-        if String::from_utf8_lossy(&output.stdout).trim().parse::<i32>().unwrap() != 0 {
+
+        if String::from_utf8_lossy(&output.stdout)
+            .trim()
+            .parse::<i32>()
+            .unwrap()
+            != 0
+        {
             result += &format!("{} (dpkg) ", String::from_utf8_lossy(&output.stdout).trim());
         }
     }
@@ -19,32 +24,53 @@ pub fn get_pkg() -> io::Result<String> {
     if Path::new("/bin/flatpak").exists() {
         let output = Command::new("sh")
             .arg("-c")
-            .arg(format!("flatpak list | wc -l"))
+            .arg("flatpak list | wc -l")
             .output()?;
 
-        if String::from_utf8_lossy(&output.stdout).trim().parse::<i32>().unwrap() != 0 {
-            result += &format!("{} (flatpak) ", String::from_utf8_lossy(&output.stdout).trim());
+        if String::from_utf8_lossy(&output.stdout)
+            .trim()
+            .parse::<i32>()
+            .unwrap()
+            != 0
+        {
+            result += &format!(
+                "{} (flatpak) ",
+                String::from_utf8_lossy(&output.stdout).trim()
+            );
         }
     }
 
     if Path::new("/bin/pacman").exists() {
         let output = Command::new("sh")
             .arg("-c")
-            .arg(format!("pacman -Qq | wc -l"))
+            .arg("pacman -Qq | wc -l")
             .output()?;
 
-        if String::from_utf8_lossy(&output.stdout).trim().parse::<i32>().unwrap() != 0 {
-            result += &format!("{} (pacman) ", String::from_utf8_lossy(&output.stdout).trim());
+        if String::from_utf8_lossy(&output.stdout)
+            .trim()
+            .parse::<i32>()
+            .unwrap()
+            != 0
+        {
+            result += &format!(
+                "{} (pacman) ",
+                String::from_utf8_lossy(&output.stdout).trim()
+            );
         }
     }
 
     if Path::new("/var/lib/rpm").exists() {
         let output = Command::new("sh")
             .arg("-c")
-            .arg(format!("rpm -qa | wc -l"))
+            .arg("rpm -qa | wc -l")
             .output()?;
 
-        if String::from_utf8_lossy(&output.stdout).trim().parse::<i32>().unwrap() != 0 {
+        if String::from_utf8_lossy(&output.stdout)
+            .trim()
+            .parse::<i32>()
+            .unwrap()
+            != 0
+        {
             result += &format!("{} (rpm) ", String::from_utf8_lossy(&output.stdout).trim());
         }
     }
@@ -52,10 +78,15 @@ pub fn get_pkg() -> io::Result<String> {
     if Path::new("/bin/snap").exists() {
         let output = Command::new("sh")
             .arg("-c")
-            .arg(format!("snap list | wc -l"))
+            .arg("snap list | wc -l")
             .output()?;
 
-        if String::from_utf8_lossy(&output.stdout).trim().parse::<i32>().unwrap() != 0 {
+        if String::from_utf8_lossy(&output.stdout)
+            .trim()
+            .parse::<i32>()
+            .unwrap()
+            != 0
+        {
             result += &format!("{} (snap) ", String::from_utf8_lossy(&output.stdout).trim());
         }
     }
@@ -63,10 +94,15 @@ pub fn get_pkg() -> io::Result<String> {
     if Path::new("/bin/xbps-install").exists() {
         let output = Command::new("sh")
             .arg("-c")
-            .arg(format!("xbps-query -l | wc -l"))
+            .arg("xbps-query -l | wc -l")
             .output()?;
 
-        if String::from_utf8_lossy(&output.stdout).trim().parse::<i32>().unwrap() != 0 {
+        if String::from_utf8_lossy(&output.stdout)
+            .trim()
+            .parse::<i32>()
+            .unwrap()
+            != 0
+        {
             result += &format!("{} (xbps) ", String::from_utf8_lossy(&output.stdout).trim());
         }
     }

--- a/src/modules/res.rs
+++ b/src/modules/res.rs
@@ -1,5 +1,5 @@
-use std::process::{Command, exit};
 use std::io;
+use std::process::{exit, Command};
 
 pub fn get_res() -> io::Result<String> {
     // Run the xrandr command and capture its output

--- a/src/modules/uptime.rs
+++ b/src/modules/uptime.rs
@@ -1,5 +1,5 @@
-use std::process::{Command, exit};
 use std::io;
+use std::process::{exit, Command};
 
 pub fn get_uptime() -> io::Result<String> {
     // Run the uptime -p command and capture its output


### PR DESCRIPTION
clippy tips:
```
warning: unneeded `return` statement
  --> src/modules/kernel.rs:14:17
   |
14 |                 return Ok(kernel_version);
   |                 ^^^^^^^^^^^^^^^^^^^^^^^^^
   |
   = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#needless_return
   = note: `#[warn(clippy::needless_return)]` on by default
help: remove `return`
   |
14 -                 return Ok(kernel_version);
14 +                 Ok(kernel_version)
   |

```
and:
```
warning: unnecessary `if let` since only the `Ok` variant of the iterator element is used
  --> src/modules/cpu.rs:9:5
   |
9  |       for line in io::BufReader::new(file).lines() {
   |       ^           -------------------------------- help: try: `io::BufReader::new(file).lines().flatten()`
   |  _____|
   | |
10 | |         if let Ok(line) = line {
11 | |             // Check for the "model name" line
12 | |             if line.starts_with("model name") {
...  |
17 | |         }
18 | |     }
   | |_____^
   |
help: ...and remove the `if let` statement in the for loop
  --> src/modules/cpu.rs:10:9
   |
10 | /         if let Ok(line) = line {
11 | |             // Check for the "model name" line
12 | |             if line.starts_with("model name") {
13 | |                 // Extract the model name
...  |
16 | |             }
17 | |         }
   | |_________^
   = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#manual_flatten
   = note: `#[warn(clippy::manual_flatten)]` on by default
```